### PR TITLE
Make variable substitution work in the body when they're not strings

### DIFF
--- a/lib/aws-sigv4.js
+++ b/lib/aws-sigv4.js
@@ -87,7 +87,7 @@ const impl = {
         // If Artillery request contains a body then copy it.
         if (requestParams.body) {
             const actualBody = varNames.reduce((accBody, name) => {
-                return accBody.split(`{{${name}}}`).join(context.vars[name])
+                return accBody.split(`{{${name}}}`).join(JSON.stringify(context.vars[name]))
             }, requestParams.body.split(' ').join(''))
             request.body = actualBody
         }
@@ -97,7 +97,7 @@ const impl = {
         if (requestParams.json) {
             const body = JSON.stringify(requestParams.json)
             const actualBody = varNames.reduce((accBody, name) => {
-                return accBody.split(`{{${name}}}`).join(context.vars[name])
+                return accBody.split(`{{${name}}}`).join(JSON.stringify(context.vars[name]))
             }, body.split(' ').join(''))
             request.body = actualBody
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artillery-plugin-aws-sigv4-http",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artillery-plugin-aws-sigv4-http",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.750.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-plugin-aws-sigv4-http",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A plugin for artillery.io that add an authentication header to every request that conforms to V4 of the AWS Signature Specification.  See https://github.com/shoreditch-ops/artillery.  Also see http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html. This version fixes some problems of the original version that can be found here: https://github.com/nordstrom/artillery-plugin-aws-sigv4/",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The current solution only works when the variable values are `strings`. If, for example they're booleans the value are converted to a string.

For example:

```json
{
    "exists": "{{ boolean_value }}"
}
```

is converted to:

```json
{
    "exists": "true"
}
```

when the correct value would be without `"`:

```json
{
    "exists": true
}
```

This is done with JSON.stringify that converts:

```js
JSON.stringify(99) == 99
JSON.stringify("99") == "99"
JSON.stringify(true) == true
JSON.stringify("true") == "true"
```